### PR TITLE
Build complete multi-page ZomiHub experience

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,35 @@
+name: Deploy ZomiHub prototype to GitHub Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Upload static site
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: "."
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# ZomiHub Interactive Library Prototype
+
+ZomiHub is an online-first cultural media hub dedicated to the preservation and celebration of the Zomi people. The platform brings together films, TV programs, music, books, and research articles so that anyone can explore, stream, and save the stories that matter to them. While the experience is designed for connected devices, every item can also be downloaded so individuals can take treasured materials with them.
+
+This repository contains a high-fidelity, multi-page front-end concept that demonstrates how members can browse the public collections, dive into format-specific experiences, and curate their own personal library once they sign in.
+
+## Key Experience Highlights
+
+- **Unified media hub:** A single interface to discover books, films, television series, and music related to the Zomi community.
+- **Personal libraries:** Signed-in members can save items and see them organized automatically into media-specific shelves that look and feel native to each format.
+- **Download ready:** Each item surfaces a download action to reinforce that visitors can keep copies for offline enjoyment when needed.
+- **Rich storytelling:** Detail views, featured curators, and contextual highlights showcase why every piece of media is meaningful.
+- **Responsive design:** The layout adapts for mobile, tablet, and desktop screens with intuitive navigation and accessible controls.
+
+## Previewing the Prototype Locally
+
+Choose the approach that best matches your tooling:
+
+- **Quick Python server (pre-installed on macOS/Linux):**
+  1. From the project directory run `python -m http.server 8000`.
+  2. Visit [http://localhost:8000](http://localhost:8000) in your browser.
+
+- **Node-powered live reload server:**
+  1. Run `npm install` to install the single `http-server` dependency.
+  2. Start the preview with `npm run dev` (serves the site at [http://localhost:4173](http://localhost:4173)).
+
+Once the server is running, explore the experience:
+   - **Home:** Get an overview of ZomiHub and try out the explore grid, timeline, and community stories.
+   - **Collections:** Filter across every media format, follow curators, and jump into curated journeys.
+   - **Books, Films, TV, Music, Articles:** Each page feels like a dedicated app with media-specific layouts and controls.
+   - **My Library:** Review everything you have saved with media-native shelves and a download queue summary.
+   - **Downloads:** Manage your offline prep list and mark items once they are stored locally.
+   - **Community & About:** Learn how to contribute, submit archives, and understand ZomiHub's mission.
+
+The prototype uses in-browser storage to remember your selections during the session, giving a realistic sense of how ZomiHub could operate once user accounts are connected to a backend service.
+
+## Publishing a Live Preview with GitHub Pages
+
+If you would like to share the prototype publicly without any additional infrastructure:
+
+1. Fork or push this repository to your own GitHub account.
+2. Ensure the repository has the default branch set to `main` (or update the workflow trigger if you prefer another branch).
+3. In the repository settings, enable **GitHub Pages** for the `GitHub Actions` source.
+4. On the next push to `main` the included workflow (`.github/workflows/deploy.yml`) will bundle the static site and deploy it to Pages.
+5. The published URL will be shown in the workflow summary and follow the pattern `https://<your-username>.github.io/<repository-name>/`.
+
+This approach keeps the experience entirely static so it remains fast, cost effective, and easy to maintain while you gather feedback from the community.
+
+## Next Steps
+
+- Implement authentication and profile management with a secure identity provider.
+- Connect the front end to a CMS or content service that stores curated Zomi media, metadata, and streaming sources.
+- Build download packaging services so media can be exported in respectful, rights-aware formats for offline personal use.
+- Expand accessibility testing, localize the interface for Zomi and English, and onboard community curators to steward collections.
+
+---
+
+Use this prototype as a collaborative starting point for designers, engineers, and Zomi cultural leaders to shape a fully featured digital home for the community.

--- a/about.html
+++ b/about.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About ZomiHub</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="about">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--about">
+        <div class="page-hero__content">
+          <p class="eyebrow">About</p>
+          <h1>Honoring the stories of the Zomi people.</h1>
+          <p>
+            ZomiHub is a community-led initiative preserving films, music, books, and oral histories created by and for the Zomi
+            people. We work with elders, historians, and artists to ensure every item is treated with care.
+          </p>
+        </div>
+      </section>
+
+      <section class="mission">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Our mission</p>
+            <h2>Preserve, educate, and celebrate</h2>
+          </div>
+        </header>
+        <div class="mission-grid">
+          <article>
+            <h3>Preservation</h3>
+            <p>Digitizing archives using community-built standards validated with cultural stewards.</p>
+          </article>
+          <article>
+            <h3>Education</h3>
+            <p>Providing learning materials, language lessons, and curriculum guides to schools and families.</p>
+          </article>
+          <article>
+            <h3>Celebration</h3>
+            <p>Sharing music, films, and stories that showcase the creativity of Zomi communities worldwide.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="team">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Team</p>
+            <h2>Stewards and contributors</h2>
+          </div>
+        </header>
+        <div class="team-grid">
+          <article>
+            <h3>Curatorial council</h3>
+            <p>A rotating group of elders, artists, and researchers guiding archival priorities.</p>
+          </article>
+          <article>
+            <h3>Technology partners</h3>
+            <p>Engineers and designers building accessible tools for streaming, downloads, and metadata.</p>
+          </article>
+          <article>
+            <h3>Community volunteers</h3>
+            <p>Contributors recording oral histories, translating content, and hosting listening sessions.</p>
+          </article>
+        </div>
+      </section>
+
+      <section class="contact">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Stay connected</p>
+            <h2>Reach the ZomiHub collective</h2>
+          </div>
+        </header>
+        <div class="contact-card">
+          <div>
+            <h3>Email</h3>
+            <p>hello@zomihub.org</p>
+          </div>
+          <div>
+            <h3>Community pledges</h3>
+            <p>All members agree to respectful use, accurate representation, and community benefit sharing.</p>
+          </div>
+          <div>
+            <h3>Newsletter</h3>
+            <p>Sign up to hear when new collections arrive and how to participate in events.</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/articles.html
+++ b/articles.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Reading Room</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="articles">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--articles">
+        <div class="page-hero__content">
+          <p class="eyebrow">Reading room</p>
+          <h1>Research, essays, and oral history transcripts.</h1>
+          <p>
+            Dive into scholarship from Zomi researchers, policy advocates, and community historians. Save articles to your library and
+            download annotated PDFs for reference.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#catalog">Browse articles</a>
+            <a class="btn secondary" href="#briefings">Briefing packets</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Research tools</h3>
+          <ul>
+            <li>Export citations in MLA and Chicago styles</li>
+            <li>Download bilingual summaries for educators</li>
+            <li>Access oral history transcripts with audio clips</li>
+          </ul>
+        </div>
+      </section>
+
+      <section
+        class="media-room"
+        id="catalog"
+        data-component="collection-browser"
+        data-default-category="article"
+        data-categories="article"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Article catalog</p>
+            <h2>Academic and community writing</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="articleSearch" class="sr-only">Search articles</label>
+            <input id="articleSearch" type="search" placeholder="Search topics or author" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="Article categories">
+          <button class="tab-btn active" role="tab" data-category="article">Articles</button>
+        </div>
+        <div class="results-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Research binder</p>
+            <h2>Organize your saved reading</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+        <div class="library-shelves">
+          <section class="shelf shelf--article" data-shelf="article">
+            <header>
+              <h3>Saved articles</h3>
+              <p>All essays, research, and transcripts you have bookmarked.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="briefing-board" id="briefings">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Briefings</p>
+            <h2>Ready-to-share packets</h2>
+          </div>
+        </header>
+        <div class="briefing-grid">
+          <article>
+            <h3>Diaspora roots pack</h3>
+            <p>Maps, essays, and interviews exploring migration routes.</p>
+          </article>
+          <article>
+            <h3>Language policy kit</h3>
+            <p>Research summaries supporting language access advocacy.</p>
+          </article>
+          <article>
+            <h3>Community wellness briefing</h3>
+            <p>Articles and oral histories on traditional healing and wellbeing.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/books.html
+++ b/books.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Bookshelf</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="books">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--books">
+        <div class="page-hero__content">
+          <p class="eyebrow">Bookshelf</p>
+          <h1>Immerse yourself in Zomi literature, folktales, and research.</h1>
+          <p>
+            From rare manuscripts to classroom lesson packs, the ZomiHub book collection is organized like a modern reading room.
+            Filter by genre, level, or topic and save everything to your shelves.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#catalog">Browse books</a>
+            <a class="btn secondary" href="#language">Language kits</a>
+            <a class="btn secondary" href="downloads.html">Download manager</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Reading modes</h3>
+          <ul>
+            <li>Responsive reader with adjustable fonts</li>
+            <li>One-click download for PDF and EPUB</li>
+            <li>Listen to narrated chapters alongside text</li>
+          </ul>
+        </div>
+      </section>
+
+      <section
+        class="media-room"
+        id="catalog"
+        data-component="collection-browser"
+        data-default-category="book"
+        data-categories="book"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Book catalog</p>
+            <h2>Curated reading lists for every learner</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="bookSearch" class="sr-only">Search books</label>
+            <input id="bookSearch" type="search" placeholder="Search by title, author, or tag" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="Book categories">
+          <button class="tab-btn active" role="tab" data-category="book">Featured books</button>
+        </div>
+        <div class="results-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Your book shelf</p>
+            <h2>Keep your reading organized</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+        <div class="library-shelves">
+          <section class="shelf shelf--book" data-shelf="book">
+            <header>
+              <h3>Saved books</h3>
+              <p>All the titles you've added from the catalog.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="guide-panel" id="language">
+        <div class="guide-panel__content">
+          <h2>Language preservation toolkit</h2>
+          <p>
+            Download printable worksheets, phonetic guides, and storybooks paired with audio pronunciation from native speakers. Each
+            resource includes classroom discussion prompts.
+          </p>
+          <a class="btn primary" href="downloads.html">Open toolkit</a>
+        </div>
+        <div class="guide-panel__media" aria-hidden="true"></div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/collections.html
+++ b/collections.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Collections</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="collections">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--collections">
+        <div class="page-hero__content">
+          <p class="eyebrow">Collections</p>
+          <h1>Browse every media format curated for the global Zomi community.</h1>
+          <p>
+            Use the filters below to explore hundreds of films, books, music albums, television series, and articles. Everything
+            you save appears instantly in your personal Zomi library and syncs across devices.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn secondary" href="books.html">View book room</a>
+            <a class="btn secondary" href="films.html">Visit cinema</a>
+            <a class="btn secondary" href="music.html">Enter music hall</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Need inspiration?</h3>
+          <p>Follow curated themes crafted with Zomi elders, educators, and historians.</p>
+          <ul>
+            <li><a href="#thematic">Festival season highlights</a></li>
+            <li><a href="#language">Language preservation sets</a></li>
+            <li><a href="#diaspora">Diaspora stories</a></li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="explore" data-component="collection-browser" data-default-category="all">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Search the archive</p>
+            <h2>Filter by category, curator, or topic</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="collectionSearch" class="sr-only">Search media</label>
+            <input id="collectionSearch" type="search" placeholder="Search titles, creators, or themes" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="Media categories">
+          <button class="tab-btn active" role="tab" data-category="all">All</button>
+          <button class="tab-btn" role="tab" data-category="book">Books</button>
+          <button class="tab-btn" role="tab" data-category="film">Films</button>
+          <button class="tab-btn" role="tab" data-category="tv">TV</button>
+          <button class="tab-btn" role="tab" data-category="music">Music</button>
+          <button class="tab-btn" role="tab" data-category="article">Articles</button>
+        </div>
+        <div class="explore__layout explore__layout--full">
+          <div class="results-grid" aria-live="polite"></div>
+          <aside class="curator-spotlight" aria-live="polite">
+            <h3>Curator spotlight</h3>
+            <p class="spotlight__name"></p>
+            <p class="spotlight__note"></p>
+            <button class="btn ghost" data-role="follow-curator">Follow curator</button>
+          </aside>
+        </div>
+      </section>
+
+      <section class="collection-guides" id="thematic">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Curated journeys</p>
+            <h2>Experience the archive like a Zomi curator</h2>
+          </div>
+        </header>
+        <div class="guide-grid">
+          <article class="guide-card">
+            <h3>Festival season</h3>
+            <p>
+              Films, playlists, and oral histories that celebrate the rhythms, dress, and culinary traditions of Zomi festivals
+              around the world.
+            </p>
+            <a class="btn tertiary" href="films.html#festival">View set</a>
+          </article>
+          <article class="guide-card" id="language">
+            <h3>Language keepers</h3>
+            <p>
+              Books, TV lessons, and music with companion PDFs that help families pass Zomi languages to new generations.
+            </p>
+            <a class="btn tertiary" href="books.html#language">Open classroom</a>
+          </article>
+          <article class="guide-card" id="diaspora">
+            <h3>Diaspora journeys</h3>
+            <p>
+              Documentaries, interviews, and essays capturing migration stories, hybrid identities, and community-building abroad.
+            </p>
+            <a class="btn tertiary" href="articles.html#diaspora">Start reading</a>
+          </article>
+        </div>
+      </section>
+
+      <section class="collection-callout" data-component="library-shelves" data-compact>
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Quick access</p>
+            <h2>Recently saved to your library</h2>
+          </div>
+          <a class="btn secondary" href="library.html">Manage full library</a>
+        </header>
+        <div class="library-shelves library-shelves--compact">
+          <section class="shelf shelf--film" data-shelf="film">
+            <header>
+              <h3>Films</h3>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--book" data-shelf="book">
+            <header>
+              <h3>Books</h3>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--music" data-shelf="music">
+            <header>
+              <h3>Music</h3>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/community.html
+++ b/community.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Community</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="community">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--community">
+        <div class="page-hero__content">
+          <p class="eyebrow">Community</p>
+          <h1>Collaborate with curators, elders, and storytellers.</h1>
+          <p>
+            ZomiHub thrives on contributions from global partners. Share your archives, host listening sessions, and help translate
+            new works for the diaspora.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#submit">Submit a collection</a>
+            <a class="btn secondary" href="#events">View upcoming events</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Community stats</h3>
+          <ul>
+            <li><strong>98</strong> verified cultural stewards</li>
+            <li><strong>640</strong> community contributed items</li>
+            <li><strong>42</strong> global listening sessions</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="community-callouts" data-component="story-switcher">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Spotlight initiatives</p>
+            <h2>Programs powered by the community</h2>
+          </div>
+        </header>
+        <div class="story-switcher">
+          <div class="story-switcher__tabs">
+            <button class="pill" data-story="archives">Archive labs</button>
+            <button class="pill" data-story="listening">Listening circles</button>
+            <button class="pill" data-story="education">Education partnerships</button>
+          </div>
+          <article class="story-card" data-story-panel="archives">
+            <h3>Archive digitization labs</h3>
+            <p>
+              Regional teams scan photographs, documents, and tapes using shared preservation kits. Volunteers add metadata and context
+              notes reviewed by elders.
+            </p>
+          </article>
+          <article class="story-card" data-story-panel="listening" hidden>
+            <h3>Monthly listening circles</h3>
+            <p>
+              Members host gatherings to share newly digitized recordings, inviting elders to provide translation and cultural insight.
+            </p>
+          </article>
+          <article class="story-card" data-story-panel="education" hidden>
+            <h3>Education exchange</h3>
+            <p>
+              Teachers across the diaspora co-create lesson plans using ZomiHub resources and share success stories during webinars.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="submission-form" id="submit">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Submit a collection</p>
+            <h2>Tell us about the materials you would like to share</h2>
+          </div>
+        </header>
+        <form class="form-grid">
+          <label>
+            Your name
+            <input type="text" placeholder="Full name" required />
+          </label>
+          <label>
+            Email address
+            <input type="email" placeholder="you@example.com" required />
+          </label>
+          <label>
+            Collection focus
+            <select required>
+              <option value="">Select an option</option>
+              <option>Music & performance</option>
+              <option>Oral histories</option>
+              <option>Photographs & documents</option>
+              <option>Educational resources</option>
+            </select>
+          </label>
+          <label class="full">
+            Description
+            <textarea rows="4" placeholder="Tell us about the items, languages, and any context we should know." required></textarea>
+          </label>
+          <label class="full">
+            Links (optional)
+            <input type="url" placeholder="https://" />
+          </label>
+          <button type="submit" class="btn primary full">Send submission</button>
+        </form>
+        <p class="form-footnote">Submissions are reviewed with cultural stewards before publishing.</p>
+      </section>
+
+      <section class="events" id="events">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Upcoming events</p>
+            <h2>Connect with Zomi communities near you</h2>
+          </div>
+        </header>
+        <div class="events-grid">
+          <article>
+            <h3>Heritage audio workshop</h3>
+            <p>Learn to digitize cassettes and preserve oral histories with portable kits.</p>
+          </article>
+          <article>
+            <h3>Festival kitchen livestream</h3>
+            <p>Cook along with Chef Van Lian and share your own family recipes.</p>
+          </article>
+          <article>
+            <h3>Story translation sprint</h3>
+            <p>Collaborate on translating folktales into English, Burmese, and Tedim dialects.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/downloads.html
+++ b/downloads.html
@@ -1,0 +1,166 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Downloads</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="downloads">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--downloads">
+        <div class="page-hero__content">
+          <p class="eyebrow">Download manager</p>
+          <h1>Prepare media for offline sharing and travel.</h1>
+          <p>
+            Items you mark for download appear here instantly. When you're ready, mark them as saved to keep track of what is stored on
+            your device.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="collections.html">Find more media</a>
+            <a class="btn secondary" href="library.html">View saved library</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Tips</h3>
+          <ul>
+            <li>Downloads remain queued until you mark them as saved offline.</li>
+            <li>Use the remove action to clean up completed files.</li>
+            <li>All downloads respect community usage guidelines.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="download-dashboard" data-component="download-center">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Queued downloads</p>
+            <h2>Your offline prep list</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-downloads">Clear download list</button>
+        </header>
+        <div class="download-empty" data-role="download-empty">
+          <p>No downloads queued. Choose any item and select download to add it here.</p>
+        </div>
+        <ul class="download-list" data-role="download-list"></ul>
+      </section>
+
+      <section class="download-guidelines">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Community guidelines</p>
+            <h2>Share responsibly</h2>
+          </div>
+        </header>
+        <div class="guideline-grid">
+          <article>
+            <h3>Respect cultural context</h3>
+            <p>Include curator notes or translations when sharing materials at events.</p>
+          </article>
+          <article>
+            <h3>Keep files secure</h3>
+            <p>Store downloads in password-protected folders when they include oral histories.</p>
+          </article>
+          <article>
+            <h3>Stay updated</h3>
+            <p>Mark items as saved once copied so you know which files exist offline.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/films.html
+++ b/films.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Cinema</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="films">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--films">
+        <div class="page-hero__content">
+          <p class="eyebrow">Cinema</p>
+          <h1>Documentaries and films capturing Zomi life.</h1>
+          <p>
+            Stream curated selections of feature films, shorts, and documentaries that preserve ceremonial music, cuisine, and
+            everyday stories of Zomi people worldwide.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#catalog">Start watching</a>
+            <a class="btn secondary" href="#festival">Festival reels</a>
+            <a class="btn secondary" href="downloads.html">Offline queue</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Projection options</h3>
+          <ul>
+            <li>Stream in HD with subtitles in English and Burmese</li>
+            <li>Download MP4s for community screenings</li>
+            <li>Access director notes and teaching guides</li>
+          </ul>
+        </div>
+      </section>
+
+      <section
+        class="media-room"
+        id="catalog"
+        data-component="collection-browser"
+        data-default-category="film"
+        data-categories="film"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Film catalog</p>
+            <h2>Featured documentaries and feature films</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="filmSearch" class="sr-only">Search films</label>
+            <input id="filmSearch" type="search" placeholder="Search by title or theme" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="Film categories">
+          <button class="tab-btn active" role="tab" data-category="film">Films</button>
+        </div>
+        <div class="results-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Your cinema shelf</p>
+            <h2>Bookmark screenings</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+        <div class="library-shelves">
+          <section class="shelf shelf--film" data-shelf="film">
+            <header>
+              <h3>Saved films</h3>
+              <p>Quick links to everything you plan to watch.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="festival-section" id="festival">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Festival spotlight</p>
+            <h2>Lamka Harvest Festival series</h2>
+          </div>
+          <a class="btn tertiary" href="downloads.html">Download screening kit</a>
+        </header>
+        <div class="festival-grid">
+          <article>
+            <h3>Opening night</h3>
+            <p>Kick off with "Mountain Songs of Resilience" followed by live Q&A.</p>
+          </article>
+          <article>
+            <h3>Artisan market stories</h3>
+            <p>Pair "Woven Paths" with behind-the-scenes interviews with textile artists.</p>
+          </article>
+          <article>
+            <h3>Closing ceremonies</h3>
+            <p>Stream "Harvest Harmony" and download community discussion prompts.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,364 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub | Cultural Media Library</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="home">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html" aria-current="page">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="hero" id="home">
+        <div class="hero__content">
+          <p class="eyebrow">The living archive of the Zomi people</p>
+          <h1>Stream, learn, and build your own Zomi cultural library online.</h1>
+          <p>
+            ZomiHub gathers films, TV programs, music, books, and oral histories into one trusted place. Save what inspires you,
+            download treasures to keep, and follow curators who honor Zomi heritage.
+          </p>
+          <div class="hero__actions">
+            <a class="btn primary" href="collections.html">Start exploring</a>
+            <button class="btn secondary" id="learnMore">How ZomiHub works</button>
+          </div>
+          <div class="hero__stats" role="list">
+            <div role="listitem">
+              <strong>480+</strong>
+              <span>Curated films & documentaries</span>
+            </div>
+            <div role="listitem">
+              <strong>1.2k</strong>
+              <span>Digitized books & manuscripts</span>
+            </div>
+            <div role="listitem">
+              <strong>230</strong>
+              <span>Community playlists & podcasts</span>
+            </div>
+          </div>
+        </div>
+        <div class="hero__preview" aria-hidden="true">
+          <div class="hero-card hero-card--film">
+            <span class="hero-card__eyebrow">Featured documentary</span>
+            <h3>Mountain Songs of Resilience</h3>
+            <p>A cinematic journey through Zomi festivals with never-before-seen footage.</p>
+            <button class="btn tertiary" data-open-id="film-mountain-songs">View details</button>
+          </div>
+          <div class="hero-card hero-card--book">
+            <span class="hero-card__eyebrow">Editor's pick</span>
+            <h3>Stories by the Hearth</h3>
+            <p>Folktales collected across four generations of storytellers.</p>
+            <button class="btn tertiary" data-open-id="book-hearth">Read excerpt</button>
+          </div>
+        </div>
+      </section>
+
+      <section class="feature-strip" id="features">
+        <article>
+          <h3>Always online</h3>
+          <p>
+            Access the full ZomiHub library from any device. Your saved collections follow you everywhere once you sign in.
+          </p>
+        </article>
+        <article>
+          <h3>Download what you love</h3>
+          <p>
+            Every item includes a download option so you can keep materials for offline study, community events, or travel.
+          </p>
+        </article>
+        <article>
+          <h3>Respectful curation</h3>
+          <p>
+            Metadata, translations, and cultural notes are reviewed with Zomi historians and elders to ensure context and care.
+          </p>
+        </article>
+      </section>
+
+      <section
+        class="explore"
+        id="explore"
+        data-component="collection-browser"
+        data-default-category="all"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Explore collections</p>
+            <h2>Discover media crafted by and for the Zomi community</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="searchInput" class="sr-only">Search media</label>
+            <input id="searchInput" type="search" placeholder="Search titles, creators, or themes" data-role="search" />
+          </div>
+        </header>
+
+        <div class="category-tabs" role="tablist" aria-label="Media categories">
+          <button class="tab-btn active" role="tab" data-category="all">All</button>
+          <button class="tab-btn" role="tab" data-category="book">Books</button>
+          <button class="tab-btn" role="tab" data-category="film">Films</button>
+          <button class="tab-btn" role="tab" data-category="tv">TV</button>
+          <button class="tab-btn" role="tab" data-category="music">Music</button>
+          <button class="tab-btn" role="tab" data-category="article">Articles</button>
+        </div>
+
+        <div class="explore__layout">
+          <div class="results-grid" aria-live="polite"></div>
+          <aside class="curator-spotlight" aria-live="polite">
+            <h3>Curator spotlight</h3>
+            <p class="spotlight__name"></p>
+            <p class="spotlight__note"></p>
+            <button class="btn ghost" data-role="follow-curator">Follow curator</button>
+          </aside>
+        </div>
+      </section>
+
+      <section class="library" id="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">My Zomi library</p>
+            <h2>Your saved collections, organized by media type</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+
+        <div class="library__notice" data-role="empty-library">
+          <h3>Your library is waiting</h3>
+          <p>
+            Start by adding books, films, TV programs, and music from the collections above. Each shelf adapts to the media so you
+            always know where you are.
+          </p>
+        </div>
+
+        <div class="library-shelves">
+          <section class="shelf shelf--book" data-shelf="book">
+            <header>
+              <h3>Book shelf</h3>
+              <p>Paginated reading lists, manuscripts, and language guides.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+
+          <section class="shelf shelf--film" data-shelf="film">
+            <header>
+              <h3>Film shelf</h3>
+              <p>Feature films, documentaries, and festival screenings.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+
+          <section class="shelf shelf--tv" data-shelf="tv">
+            <header>
+              <h3>TV shelf</h3>
+              <p>Series, interviews, and episodic cultural programs.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+
+          <section class="shelf shelf--music" data-shelf="music">
+            <header>
+              <h3>Music shelf</h3>
+              <p>Albums, live recordings, and curated playlists.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+
+          <section class="shelf shelf--article" data-shelf="article">
+            <header>
+              <h3>Articles & research</h3>
+              <p>Academic writing, historical essays, and community journals.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="timeline" data-component="timeline">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">ZomiHub roadmap</p>
+            <h2>Track how the cultural hub keeps growing</h2>
+          </div>
+        </header>
+        <div class="timeline__controls">
+          <button class="pill" data-stage="collect">Collection</button>
+          <button class="pill" data-stage="preserve">Preservation</button>
+          <button class="pill" data-stage="share">Community sharing</button>
+        </div>
+        <div class="timeline__panels">
+          <article data-stage-panel="collect">
+            <h3>Collecting heritage</h3>
+            <p>
+              Community teams digitize family archives, festivals, and manuscripts using preservation-grade workflows aligned with
+              Zomi elders.
+            </p>
+          </article>
+          <article data-stage-panel="preserve" hidden>
+            <h3>Preserving context</h3>
+            <p>
+              Linguists and historians verify translations, add cultural notes, and build metadata so every piece keeps its meaning
+              across languages.
+            </p>
+          </article>
+          <article data-stage-panel="share" hidden>
+            <h3>Sharing responsibly</h3>
+            <p>
+              Members stream online, save to their libraries, and download for educational events while respecting stewardship
+              guidelines.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="community-stories" data-component="story-switcher">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Community voices</p>
+            <h2>Hear how ZomiHub is used around the world</h2>
+          </div>
+        </header>
+        <div class="story-switcher">
+          <div class="story-switcher__tabs">
+            <button class="pill" data-story="festival">Festival organizer</button>
+            <button class="pill" data-story="teacher">Language teacher</button>
+            <button class="pill" data-story="diaspora">Diaspora family</button>
+          </div>
+          <article class="story-card" data-story-panel="festival">
+            <h3>Preserving Lamka Festival sets</h3>
+            <p>
+              "We screen documentaries from the ZomiHub film collection before each performance so our youth see the rituals they
+              inherit." — Nawng, festival lead
+            </p>
+          </article>
+          <article class="story-card" data-story-panel="teacher" hidden>
+            <h3>Language classrooms abroad</h3>
+            <p>
+              "Our students build playlists of Zomi songs and download lesson packets from the books shelf to practice every week." —
+              Ling, community teacher
+            </p>
+          </article>
+          <article class="story-card" data-story-panel="diaspora" hidden>
+            <h3>Family storytelling nights</h3>
+            <p>
+              "We saved oral histories and films into our library so grandparents can share memories even when we're far apart." —
+              The Khai family
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="community" id="community">
+        <div class="community__content">
+          <h2>Contribute to the growing Zomi story</h2>
+          <p>
+            Share family archives, publish new works, host listening sessions, and help catalog translations. ZomiHub connects
+            creators, elders, and learners across the globe.
+          </p>
+          <div class="community__actions">
+            <a class="btn primary" href="community.html">Become a curator</a>
+            <a class="btn secondary" href="community.html#submit">Submit a collection</a>
+          </div>
+        </div>
+        <ul class="community__stats" role="list">
+          <li>
+            <strong>98</strong>
+            <span>Verified cultural stewards</span>
+          </li>
+          <li>
+            <strong>640</strong>
+            <span>Community contributed items</span>
+          </li>
+          <li>
+            <strong>42</strong>
+            <span>Global listening sessions hosted</span>
+          </li>
+        </ul>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/library.html
+++ b/library.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>My ZomiHub Library</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="library">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--library">
+        <div class="page-hero__content">
+          <p class="eyebrow">My library</p>
+          <h1>Everything you've saved across books, films, TV, music, and research.</h1>
+          <p>
+            Your ZomiHub shelves sync instantly between the website and mobile app. Download anything to keep offline or share with
+            your community events.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="collections.html">Add more items</a>
+            <a class="btn secondary" href="downloads.html">Manage downloads</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Library summary</h3>
+          <ul class="summary-list">
+            <li><strong data-library-count="total">0</strong> total items saved</li>
+            <li><strong data-library-count="book">0</strong> books & articles</li>
+            <li><strong data-library-count="film">0</strong> films</li>
+            <li><strong data-library-count="tv">0</strong> TV series</li>
+            <li><strong data-library-count="music">0</strong> albums & playlists</li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Saved items</p>
+            <h2>Organized shelves by media type</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear entire library</button>
+        </header>
+        <div class="library__notice" data-library-empty="total" data-role="empty-library">
+          <h3>Your library is empty</h3>
+          <p>Browse collections and add items to see them appear here instantly.</p>
+        </div>
+        <div class="library-shelves">
+          <section class="shelf shelf--book" data-shelf="book">
+            <header>
+              <h3>Books</h3>
+              <p>Digitized manuscripts, lesson plans, and folktale anthologies.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--film" data-shelf="film">
+            <header>
+              <h3>Films</h3>
+              <p>Feature films, documentaries, and cultural shorts.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--tv" data-shelf="tv">
+            <header>
+              <h3>TV</h3>
+              <p>Series, interviews, and educational programming.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--music" data-shelf="music">
+            <header>
+              <h3>Music</h3>
+              <p>Albums, playlists, and ceremonial recordings.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+          <section class="shelf shelf--article" data-shelf="article">
+            <header>
+              <h3>Articles & research</h3>
+              <p>Essays, policy briefings, and oral history transcripts.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="download-preview" data-component="download-center">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Download queue</p>
+            <h2>Items you prepared for offline use</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-downloads">Clear download list</button>
+        </header>
+        <div class="download-empty" data-role="download-empty">
+          <p>No downloads yet. Click download on any item to queue it here.</p>
+        </div>
+        <ul class="download-list" data-role="download-list"></ul>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/music.html
+++ b/music.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub Music Hall</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="music">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--music">
+        <div class="page-hero__content">
+          <p class="eyebrow">Music Hall</p>
+          <h1>Listen to archival recordings and contemporary sounds.</h1>
+          <p>
+            Discover choirs, traditional ensembles, and modern remixes that honor Zomi rhythms. Build playlists for cultural events
+            or personal study, and download tracks to take them on the road.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#catalog">Browse albums</a>
+            <a class="btn secondary" href="#mixes">Curated mixes</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Audio features</h3>
+          <ul>
+            <li>Stream lossless audio with adaptive bitrate</li>
+            <li>Download MP3 bundles for events</li>
+            <li>Access lyric sheets and translations</li>
+          </ul>
+        </div>
+      </section>
+
+      <section
+        class="media-room"
+        id="catalog"
+        data-component="collection-browser"
+        data-default-category="music"
+        data-categories="music"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Music catalog</p>
+            <h2>Albums and playlists</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="musicSearch" class="sr-only">Search music</label>
+            <input id="musicSearch" type="search" placeholder="Search albums or artist" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="Music categories">
+          <button class="tab-btn active" role="tab" data-category="music">Music</button>
+        </div>
+        <div class="results-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Your playlists</p>
+            <h2>Keep your favorite sounds close</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+        <div class="library-shelves">
+          <section class="shelf shelf--music" data-shelf="music">
+            <header>
+              <h3>Saved albums</h3>
+              <p>Everything you have added for listening sessions.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="mix-board" id="mixes">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Featured playlists</p>
+            <h2>Curated by community DJs</h2>
+          </div>
+        </header>
+        <div class="mix-grid">
+          <article>
+            <h3>Festival sunrise</h3>
+            <p>Wake up the village with ceremonial drums and upbeat choruses.</p>
+          </article>
+          <article>
+            <h3>Heritage lullabies</h3>
+            <p>Soothing tracks recorded across three generations of singers.</p>
+          </article>
+          <article>
+            <h3>Dance the diaspora</h3>
+            <p>Club remixes blending traditional percussion with modern synths.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "zomihub-prototype",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Interactive static prototype for the ZomiHub cultural media hub.",
+  "scripts": {
+    "dev": "http-server -p 4173 -c-1 ."
+  },
+  "devDependencies": {
+    "http-server": "^14.1.1"
+  }
+}

--- a/script.js
+++ b/script.js
@@ -1,0 +1,1074 @@
+const MEDIA_TYPES = {
+  book: { label: "Book", shelfLabel: "Books", accent: "#CBA96E" },
+  film: { label: "Film", shelfLabel: "Films", accent: "#EC6A5F" },
+  tv: { label: "TV", shelfLabel: "TV", accent: "#6C80FF" },
+  music: { label: "Music", shelfLabel: "Music", accent: "#3CBF8A" },
+  article: { label: "Article", shelfLabel: "Articles", accent: "#9C6CFF" },
+};
+
+const CATALOG = [
+  {
+    id: "book-hearth",
+    type: "book",
+    title: "Stories by the Hearth",
+    creator: "Anthology curated by Cin Khai",
+    year: 2022,
+    duration: "368 pages",
+    summary:
+      "A modern compilation of folktales collected from elders in Tedim, Tonzang, and Falam townships, presented with side-by-side translations.",
+    tags: ["Folklore", "Language", "Family"],
+    image:
+      "https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "book-living-archives",
+    type: "book",
+    title: "Living Archives: Zomi Women in Their Own Words",
+    creator: "Hnem Hil's oral history project",
+    year: 2019,
+    duration: "212 pages",
+    summary:
+      "Transcribed interviews with Zomi women across generations, highlighting leadership, family traditions, and migration stories.",
+    tags: ["Oral History", "Women", "Diaspora"],
+    image:
+      "https://images.unsplash.com/photo-1481627834876-b7833e8f5570?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "book-linguistic",
+    type: "book",
+    title: "Zomi Language Companion",
+    creator: "Zomi Language Preservation Council",
+    year: 2023,
+    duration: "145 pages",
+    summary:
+      "Lesson plans and pronunciation guides for diaspora classrooms with QR codes linking to native speaker audio.",
+    tags: ["Language", "Education"],
+    image:
+      "https://images.unsplash.com/photo-1516979187457-637abb4f9353?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "book-oral-proverbs",
+    type: "book",
+    title: "Proverbs of the Highlands",
+    creator: "Curated by the Zomi Proverbs Circle",
+    year: 2020,
+    duration: "189 pages",
+    summary:
+      "Parallel language presentation of 420 beloved Zomi proverbs with annotations from elders across the region.",
+    tags: ["Wisdom", "Language"],
+    image:
+      "https://images.unsplash.com/photo-1514894780887-121968d00567?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "film-mountain-songs",
+    type: "film",
+    title: "Mountain Songs of Resilience",
+    creator: "Directed by Zam Mang",
+    year: 2021,
+    duration: "78 min",
+    summary:
+      "A documentary following musicians as they compose new festival music inspired by ancestral drum patterns.",
+    tags: ["Music", "Festival", "Documentary"],
+    image:
+      "https://images.unsplash.com/photo-1516035069371-29a1b244cc32?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "film-woven-paths",
+    type: "film",
+    title: "Woven Paths",
+    creator: "Produced by Zomi Cultural Trust",
+    year: 2020,
+    duration: "96 min",
+    summary:
+      "An immersive film capturing loom weaving traditions, from preparing dyes to celebrating the finished textiles in village ceremonies.",
+    tags: ["Art", "Weaving"],
+    image:
+      "https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "film-harvest-harmony",
+    type: "film",
+    title: "Harvest Harmony",
+    creator: "Festival of Seeds initiative",
+    year: 2024,
+    duration: "54 min",
+    summary:
+      "A seasonal look at Zomi agricultural rituals and communal feasts that accompany rice harvests in the highlands.",
+    tags: ["Agriculture", "Festival"],
+    image:
+      "https://images.unsplash.com/photo-1472145246862-b24cf25c4a36?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "film-colors-of-homes",
+    type: "film",
+    title: "Colors of Home",
+    creator: "Zomi Youth Filmmakers",
+    year: 2018,
+    duration: "64 min",
+    summary:
+      "Portraits of Zomi artists who paint murals documenting migration, belonging, and intergenerational bonds.",
+    tags: ["Art", "Diaspora"],
+    image:
+      "https://images.unsplash.com/photo-1478720568477-152d9b164e26?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "tv-diaspora-journal",
+    type: "tv",
+    title: "Diaspora Journal",
+    creator: "ZomiHub Studios",
+    year: 2023,
+    duration: "Season 2",
+    summary:
+      "A television series interviewing Zomi families across the globe about how they keep cultural traditions alive.",
+    tags: ["Interview", "Diaspora"],
+    image:
+      "https://images.unsplash.com/photo-1525182008055-f88b95ff7980?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "tv-mountain-classroom",
+    type: "tv",
+    title: "Mountain Classroom",
+    creator: "Hosted by Nuam Bawi",
+    year: 2022,
+    duration: "Season 1",
+    summary:
+      "An educational TV program teaching Zomi language and geography through animated storytelling and field trips.",
+    tags: ["Education", "Language"],
+    image:
+      "https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "tv-culinary-trails",
+    type: "tv",
+    title: "Culinary Trails",
+    creator: "Chef Van Lian",
+    year: 2024,
+    duration: "Season 3",
+    summary:
+      "Each episode explores Zomi cuisine with guest cooks, highlighting locally grown ingredients and festive dishes.",
+    tags: ["Cuisine", "Lifestyle"],
+    image:
+      "https://images.unsplash.com/photo-1515003197210-e0cd71810b5f?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "tv-festival-chronicles",
+    type: "tv",
+    title: "Festival Chronicles",
+    creator: "Broadcast Collective",
+    year: 2019,
+    duration: "Season 4",
+    summary:
+      "Coverage of annual Zomi festivals with live performances, elder interviews, and behind-the-scenes preparations.",
+    tags: ["Festival", "Culture"],
+    image:
+      "https://images.unsplash.com/photo-1529333166437-7750a6dd5a70?auto=format&fit=crop&w=640&q=80",
+  },
+  {
+    id: "music-hills-chorus",
+    type: "music",
+    title: "Chorus of the Hills",
+    creator: "Falam Youth Choir",
+    year: 2021,
+    duration: "12 tracks",
+    summary:
+      "A choral album blending traditional harmonies with contemporary arrangements recorded live at community gatherings.",
+    tags: ["Choir", "Live"],
+    image:
+      "https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "music-pulse-of-chins",
+    type: "music",
+    title: "Pulse of the Chins",
+    creator: "DJ Mang Tual",
+    year: 2020,
+    duration: "9 tracks",
+    summary:
+      "Electronic remixes of ceremonial drum rhythms designed for dance gatherings and cultural festivals abroad.",
+    tags: ["Electronic", "Festival"],
+    image:
+      "https://images.unsplash.com/photo-1526948128573-703ee1aeb6fa?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "music-lullabies",
+    type: "music",
+    title: "Lullabies Across Generations",
+    creator: "Lenchi & Family",
+    year: 2018,
+    duration: "15 tracks",
+    summary:
+      "A gentle collection of bedtime songs recorded with grandparents and grandchildren in home studios.",
+    tags: ["Family", "Tradition"],
+    image:
+      "https://images.unsplash.com/photo-1511671782779-c97d3d27a1d4?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "music-strings-of-home",
+    type: "music",
+    title: "Strings of Home",
+    creator: "Zophei Ensemble",
+    year: 2022,
+    duration: "11 tracks",
+    summary:
+      "Instrumental recordings featuring bamboo zithers, flutes, and percussion used in traditional ceremonies.",
+    tags: ["Instrumental", "Tradition"],
+    image:
+      "https://images.unsplash.com/photo-1507838153414-b4b713384a76?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "article-oral-histories",
+    type: "article",
+    title: "Archiving Oral Histories with Care",
+    creator: "Zomi Research Collective",
+    year: 2023,
+    duration: "17 min read",
+    summary:
+      "Best practices for recording, translating, and cataloging oral histories in collaboration with elders and community leaders.",
+    tags: ["Research", "Oral History"],
+    image:
+      "https://images.unsplash.com/photo-1532012197267-da84d127e765?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "article-diaspora-roots",
+    type: "article",
+    title: "Diaspora Roots: Mapping Zomi Migration",
+    creator: "K. Tuan Boi",
+    year: 2022,
+    duration: "12 min read",
+    summary:
+      "An interactive essay tracing key migration waves and the cultural centers that emerged in each region.",
+    tags: ["Diaspora", "History"],
+    image:
+      "https://images.unsplash.com/photo-1526778548025-fa2f459cd5c1?auto=format&fit=crop&w=480&q=80",
+  },
+  {
+    id: "article-heritage-cuisine",
+    type: "article",
+    title: "Heritage Cuisine for Modern Kitchens",
+    creator: "Chef Pawlian",
+    year: 2021,
+    duration: "9 min read",
+    summary:
+      "A culinary primer that adapts ceremonial dishes for small apartments while keeping ancestral flavors intact.",
+    tags: ["Cuisine", "Lifestyle"],
+    image:
+      "https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=480&q=80",
+  },
+];
+
+const CURATOR_SPOTLIGHTS = {
+  all: {
+    name: "The Cultural Council",
+    note: "A rotating panel featuring educators, historians, and artists sharing their must-watch picks each month.",
+  },
+  book: {
+    name: "Nu Thang (Literary Steward)",
+    note: "Nu Thang digitizes rare manuscripts and pairs them with contemporary fiction to show how stories evolve.",
+  },
+  film: {
+    name: "Van Zam (Documentary Filmmaker)",
+    note: "Van Zam curates films that capture environmental stewardship and festival life across the Chin Hills.",
+  },
+  tv: {
+    name: "Tuan Mawi (Broadcast Producer)",
+    note: "Tuan highlights episodic programs that are perfect for family watch nights and classroom screenings.",
+  },
+  music: {
+    name: "Lenchi (Community DJ)",
+    note: "Lenchi blends archival recordings with contemporary artists to create playlists for every celebration.",
+  },
+  article: {
+    name: "Dr. Hang (Cultural Researcher)",
+    note: "Dr. Hang surfaces research and essays that provide deeper context for Zomi history and policy.",
+  },
+};
+
+const STORAGE_KEYS = {
+  library: "zomihub-library-state",
+  downloads: "zomihub-download-queue",
+  following: "zomihub-following",
+};
+
+const appState = {
+  library: loadLibrary(),
+  downloads: loadDownloads(),
+  following: loadFollowing(),
+  modalItemId: null,
+};
+
+const collectionInstances = [];
+const libraryInstances = [];
+const downloadInstances = [];
+
+document.addEventListener("DOMContentLoaded", () => {
+  const page = document.body.dataset.page || "home";
+
+  initGlobalChrome(page);
+  initCollectionBrowsers();
+  initLibraryShelves();
+  initDownloadCenters();
+  initTimeline();
+  initStorySwitchers();
+
+  if (page === "home") {
+    initHomeHighlights();
+  }
+});
+
+function loadLibrary() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEYS.library);
+    if (saved) {
+      const parsed = JSON.parse(saved);
+      return { ...defaultLibraryState(), ...parsed };
+    }
+  } catch (error) {
+    console.warn("Unable to load library from storage", error);
+  }
+  return defaultLibraryState();
+}
+
+function loadDownloads() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEYS.downloads);
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch (error) {
+    console.warn("Unable to load downloads from storage", error);
+  }
+  return [];
+}
+
+function loadFollowing() {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEYS.following);
+    if (saved) {
+      return JSON.parse(saved);
+    }
+  } catch (error) {
+    console.warn("Unable to load followed curators", error);
+  }
+  return [];
+}
+
+function defaultLibraryState() {
+  return {
+    book: [],
+    film: [],
+    tv: [],
+    music: [],
+    article: [],
+  };
+}
+
+function saveLibrary() {
+  localStorage.setItem(STORAGE_KEYS.library, JSON.stringify(appState.library));
+}
+
+function saveDownloads() {
+  localStorage.setItem(STORAGE_KEYS.downloads, JSON.stringify(appState.downloads));
+}
+
+function saveFollowing() {
+  localStorage.setItem(STORAGE_KEYS.following, JSON.stringify(appState.following));
+}
+
+function initGlobalChrome(page) {
+  initNavigation(page);
+  initAccountPanel();
+  initModal();
+  initToast();
+}
+
+function initNavigation(page) {
+  const menuToggle = document.getElementById("menuToggle");
+  const primaryNav = document.querySelector(".primary-nav");
+
+  if (menuToggle && primaryNav) {
+    menuToggle.addEventListener("click", () => {
+      menuToggle.classList.toggle("open");
+      primaryNav.classList.toggle("open");
+    });
+
+    primaryNav.querySelectorAll("a").forEach((link) => {
+      link.addEventListener("click", () => {
+        menuToggle.classList.remove("open");
+        primaryNav.classList.remove("open");
+      });
+    });
+  }
+
+  const navLinks = document.querySelectorAll("[data-nav]");
+  navLinks.forEach((link) => {
+    if (link.dataset.nav === page) {
+      link.classList.add("active");
+      link.setAttribute("aria-current", "page");
+    } else {
+      link.classList.remove("active");
+      link.removeAttribute("aria-current");
+    }
+  });
+}
+
+function initAccountPanel() {
+  const accountPanel = document.getElementById("accountPanel");
+  const signInButton = document.getElementById("signInButton");
+  const closeAccountPanel = document.getElementById("closeAccountPanel");
+  const createAccountButton = document.getElementById("createAccount");
+  const accountForm = document.querySelector(".account-form");
+
+  if (!accountPanel) return;
+
+  const openPanel = () => {
+    accountPanel.setAttribute("aria-hidden", "false");
+    accountPanel.classList.add("open");
+  };
+
+  const closePanel = () => {
+    accountPanel.setAttribute("aria-hidden", "true");
+    accountPanel.classList.remove("open");
+  };
+
+  signInButton?.addEventListener("click", openPanel);
+  closeAccountPanel?.addEventListener("click", closePanel);
+  accountPanel.addEventListener("click", (event) => {
+    if (event.target === accountPanel) closePanel();
+  });
+  createAccountButton?.addEventListener("click", () => {
+    showToast("Account creation will open registration flow soon.");
+  });
+  accountForm?.addEventListener("submit", (event) => {
+    event.preventDefault();
+    showToast("Demo only – authentication will be connected later.");
+  });
+
+  const downloadCenterButton = document.getElementById("downloadCenter");
+  downloadCenterButton?.addEventListener("click", (event) => {
+    if (downloadCenterButton.tagName === "BUTTON") {
+      event.preventDefault();
+      window.location.href = "downloads.html";
+    }
+  });
+}
+
+let modalElements = null;
+
+function initModal() {
+  const modal = document.getElementById("itemModal");
+  if (!modal) return;
+
+  modalElements = {
+    modal,
+    modalTitle: document.getElementById("modalTitle"),
+    modalType: modal.querySelector(".modal__type"),
+    modalMeta: modal.querySelector(".modal__meta"),
+    modalDescription: modal.querySelector(".modal__description"),
+    modalMedia: modal.querySelector(".modal__media"),
+    modalSaveBtn: document.getElementById("modalSave"),
+    modalDownloadBtn: document.getElementById("modalDownload"),
+    closeModalBtn: document.getElementById("closeModal"),
+  };
+
+  modalElements.closeModalBtn?.addEventListener("click", closeModal);
+  modal.addEventListener("click", (event) => {
+    if (event.target === modal) closeModal();
+  });
+
+  modalElements.modalSaveBtn?.addEventListener("click", () => {
+    if (!appState.modalItemId) return;
+    toggleLibraryItem(appState.modalItemId);
+  });
+
+  modalElements.modalDownloadBtn?.addEventListener("click", () => {
+    if (!appState.modalItemId) return;
+    const item = getItem(appState.modalItemId);
+    simulateDownload(item);
+  });
+
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && modal.classList.contains("open")) {
+      closeModal();
+    }
+  });
+}
+
+let toastElement = null;
+
+function initToast() {
+  toastElement = document.getElementById("toast");
+}
+
+function initCollectionBrowsers() {
+  const sections = document.querySelectorAll('[data-component="collection-browser"]');
+  sections.forEach((section) => {
+    const instance = createCollectionBrowser(section);
+    if (instance) {
+      collectionInstances.push(instance);
+    }
+  });
+}
+function createCollectionBrowser(section) {
+  const resultsGrid = section.querySelector(".results-grid");
+  if (!resultsGrid) return null;
+
+  const defaultCategory = section.dataset.defaultCategory || "all";
+  const allowed = section.dataset.categories
+    ? section.dataset.categories.split(",").map((entry) => entry.trim())
+    : null;
+
+  const state = {
+    activeCategory: defaultCategory,
+    searchTerm: "",
+  };
+
+  const tabButtons = Array.from(section.querySelectorAll(".tab-btn"));
+  const searchInput = section.querySelector("[data-role=\"search\"]") || section.querySelector("input[type=\"search\"]");
+  const curatorName = section.querySelector(".spotlight__name");
+  const curatorNote = section.querySelector(".spotlight__note");
+  const followCuratorBtn = section.querySelector('[data-role="follow-curator"]');
+
+  if (allowed && tabButtons.length) {
+    tabButtons.forEach((button) => {
+      const category = button.dataset.category;
+      if (category !== "all" && !allowed.includes(category)) {
+        button.remove();
+      }
+    });
+  }
+
+  function setActiveCategory(category) {
+    state.activeCategory = category;
+    tabButtons.forEach((button) => {
+      button.classList.toggle("active", button.dataset.category === category);
+    });
+    updateSpotlight();
+    renderCatalog();
+  }
+
+  function updateSpotlight() {
+    if (!curatorName || !curatorNote) return;
+    const spotlight = CURATOR_SPOTLIGHTS[state.activeCategory] || CURATOR_SPOTLIGHTS.all;
+    curatorName.textContent = spotlight.name;
+    curatorNote.textContent = spotlight.note;
+  }
+
+  function renderCatalog() {
+    const filtered = CATALOG.filter((item) => {
+      const matchesCategory =
+        state.activeCategory === "all" || item.type === state.activeCategory;
+      const matchesAllowed = !allowed || allowed.includes(item.type);
+      const matchesSearch = state.searchTerm
+        ? [item.title, item.creator, ...(item.tags || [])]
+            .join(" ")
+            .toLowerCase()
+            .includes(state.searchTerm.toLowerCase())
+        : true;
+      return matchesCategory && matchesAllowed && matchesSearch;
+    });
+
+    resultsGrid.innerHTML = "";
+
+    if (!filtered.length) {
+      const empty = document.createElement("div");
+      empty.className = "empty-state";
+      empty.innerHTML = `
+        <h3>No results found</h3>
+        <p>Try adjusting your filters or searching for another title.</p>
+      `;
+      resultsGrid.append(empty);
+      return;
+    }
+
+    filtered.forEach((item) => {
+      resultsGrid.append(createMediaCard(item));
+    });
+  }
+
+  resultsGrid.addEventListener("click", (event) => {
+    const action = event.target.dataset.action;
+    if (!action) return;
+    const id = event.target.dataset.id;
+    const item = getItem(id);
+
+    if (!item) return;
+
+    if (action === "toggle") {
+      toggleLibraryItem(id);
+    } else if (action === "details") {
+      openModal(item);
+    } else if (action === "download") {
+      simulateDownload(item);
+    }
+  });
+
+  tabButtons.forEach((button) => {
+    button.addEventListener("click", () => {
+      setActiveCategory(button.dataset.category);
+    });
+  });
+
+  if (searchInput) {
+    searchInput.addEventListener("input", (event) => {
+      state.searchTerm = event.target.value.trim();
+      renderCatalog();
+    });
+  }
+
+  if (followCuratorBtn) {
+    followCuratorBtn.addEventListener("click", () => {
+      const active = state.activeCategory;
+      if (!appState.following.includes(active)) {
+        appState.following.push(active);
+        saveFollowing();
+      }
+      const spotlight = CURATOR_SPOTLIGHTS[active] || CURATOR_SPOTLIGHTS.all;
+      showToast(`You will now receive updates from ${spotlight.name}.`);
+    });
+  }
+
+  setActiveCategory(defaultCategory);
+  updateSpotlight();
+  renderCatalog();
+
+  return {
+    refresh: renderCatalog,
+  };
+}
+
+function initLibraryShelves() {
+  const sections = document.querySelectorAll('[data-component="library-shelves"]');
+  sections.forEach((section) => {
+    const instance = createLibrarySection(section);
+    if (instance) {
+      libraryInstances.push(instance);
+    }
+  });
+  updateLibrarySummaries();
+}
+
+function createLibrarySection(section) {
+  const clearButton = section.querySelector('[data-action="clear-library"]');
+  const emptyState = section.querySelector('[data-role="empty-library"]');
+  const shelves = Array.from(section.querySelectorAll(".shelf"));
+
+  if (!shelves.length) return null;
+
+  section.addEventListener("click", (event) => {
+    const action = event.target.dataset.action;
+    if (!action) return;
+    const id = event.target.dataset.id;
+    const item = getItem(id);
+
+    if (action === "remove") {
+      toggleLibraryItem(id);
+    } else if (action === "download" && item) {
+      simulateDownload(item);
+    }
+  });
+
+  clearButton?.addEventListener("click", () => {
+    clearLibrary();
+  });
+
+  function render() {
+    let totalSaved = 0;
+
+    shelves.forEach((shelf) => {
+      const type = shelf.dataset.shelf;
+      const content = shelf.querySelector(".shelf__content");
+      if (!content) return;
+
+      const items = (appState.library[type] || []).map(getItem).filter(Boolean);
+      content.innerHTML = "";
+
+      if (!items.length) {
+        const empty = document.createElement("p");
+        empty.className = "shelf__empty";
+        empty.textContent = `No ${MEDIA_TYPES[type].shelfLabel.toLowerCase()} saved yet.`;
+        content.append(empty);
+      } else {
+        totalSaved += items.length;
+        items.forEach((item) => {
+          content.append(createShelfItem(item));
+        });
+      }
+    });
+
+    if (emptyState) {
+      emptyState.hidden = totalSaved > 0;
+    }
+  }
+
+  render();
+  return { render };
+}
+
+function initDownloadCenters() {
+  const sections = document.querySelectorAll('[data-component="download-center"]');
+  sections.forEach((section) => {
+    const instance = createDownloadCenter(section);
+    if (instance) {
+      downloadInstances.push(instance);
+    }
+  });
+}
+
+function createDownloadCenter(section) {
+  const list = section.querySelector('[data-role="download-list"]');
+  if (!list) return null;
+
+  const emptyState = section.querySelector('[data-role="download-empty"]');
+  const clearButton = section.querySelector('[data-action="clear-downloads"]');
+
+  section.addEventListener("click", (event) => {
+    const action = event.target.dataset.action;
+    if (!action) return;
+    const id = event.target.dataset.id;
+
+    if (action === "remove-download") {
+      appState.downloads = appState.downloads.filter((entry) => entry.id !== id);
+      saveDownloads();
+      render();
+      showToast("Removed from downloads.");
+    } else if (action === "mark-complete") {
+      const entry = appState.downloads.find((item) => item.id === id);
+      if (entry) {
+        entry.status = "Saved offline";
+        entry.updatedAt = Date.now();
+        saveDownloads();
+        render();
+        showToast("Marked as saved offline.");
+      }
+    }
+  });
+
+  clearButton?.addEventListener("click", () => {
+    appState.downloads = [];
+    saveDownloads();
+    render();
+    showToast("Download list cleared.");
+  });
+
+  function render() {
+    list.innerHTML = "";
+
+    if (!appState.downloads.length) {
+      if (emptyState) emptyState.hidden = false;
+      return;
+    }
+
+    if (emptyState) emptyState.hidden = true;
+
+    const sorted = [...appState.downloads].sort((a, b) => b.updatedAt - a.updatedAt);
+
+    sorted.forEach((entry) => {
+      const item = getItem(entry.id);
+      if (!item) return;
+      list.append(createDownloadRow(item, entry));
+    });
+  }
+
+  render();
+  return { render };
+}
+
+function initTimeline() {
+  const timeline = document.querySelector("[data-component=\"timeline\"]");
+  if (!timeline) return;
+
+  const stages = timeline.querySelectorAll("button[data-stage]");
+  const panels = timeline.querySelectorAll("[data-stage-panel]");
+
+  stages.forEach((stage) => {
+    stage.addEventListener("click", () => {
+      const target = stage.dataset.stage;
+      stages.forEach((btn) => btn.classList.toggle("active", btn === stage));
+      panels.forEach((panel) => {
+        panel.hidden = panel.dataset.stagePanel !== target;
+      });
+    });
+  });
+
+  const first = stages[0];
+  if (first) first.click();
+}
+
+function initStorySwitchers() {
+  document.querySelectorAll("[data-component=\"story-switcher\"]").forEach((component) => {
+    const buttons = component.querySelectorAll("button[data-story]");
+    const stories = component.querySelectorAll("[data-story-panel]");
+
+    buttons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const target = button.dataset.story;
+        buttons.forEach((btn) => btn.classList.toggle("active", btn === button));
+        stories.forEach((panel) => {
+          panel.hidden = panel.dataset.storyPanel !== target;
+        });
+      });
+    });
+
+    const first = buttons[0];
+    if (first) first.click();
+  });
+}
+
+function initHomeHighlights() {
+  const learnMoreBtn = document.getElementById("learnMore");
+  if (learnMoreBtn) {
+    learnMoreBtn.addEventListener("click", () => {
+      const target = document.getElementById("features");
+      target?.scrollIntoView({ behavior: "smooth" });
+    });
+  }
+
+  document.querySelectorAll('[data-open-id]').forEach((button) => {
+    button.addEventListener("click", () => {
+      const item = getItem(button.dataset.openId);
+      if (item) {
+        openModal(item);
+      }
+    });
+  });
+}
+
+function renderAllLibraries() {
+  libraryInstances.forEach((instance) => instance.render());
+  updateLibrarySummaries();
+}
+
+function updateLibrarySummaries() {
+  document.querySelectorAll('[data-library-count]').forEach((node) => {
+    const type = node.dataset.libraryCount;
+    if (type === "total") {
+      const total = Object.values(appState.library).reduce((sum, items) => sum + items.length, 0);
+      node.textContent = total;
+    } else if (appState.library[type]) {
+      node.textContent = appState.library[type].length;
+    }
+  });
+
+  document.querySelectorAll('[data-library-empty]').forEach((node) => {
+    const type = node.dataset.libraryEmpty;
+    if (type === "total") {
+      const total = Object.values(appState.library).every((items) => items.length === 0);
+      node.hidden = total ? false : true;
+    } else if (appState.library[type]) {
+      node.hidden = appState.library[type].length !== 0;
+    }
+  });
+}
+
+function refreshCollectionBrowsers() {
+  collectionInstances.forEach((instance) => instance.refresh());
+}
+
+function refreshDownloadCenters() {
+  downloadInstances.forEach((instance) => instance.render());
+}
+
+function isSaved(id) {
+  return Object.values(appState.library).some((entries) => entries.includes(id));
+}
+
+function getItem(id) {
+  return CATALOG.find((item) => item.id === id);
+}
+
+function toggleLibraryItem(id) {
+  const item = getItem(id);
+  if (!item) return;
+
+  const list = appState.library[item.type];
+  const index = list.indexOf(id);
+
+  if (index === -1) {
+    list.push(id);
+    showToast(`${item.title} added to your ${MEDIA_TYPES[item.type].shelfLabel.toLowerCase()}.`);
+  } else {
+    list.splice(index, 1);
+    showToast(`${item.title} removed from your library.`);
+  }
+
+  saveLibrary();
+  refreshCollectionBrowsers();
+  renderAllLibraries();
+  updateModalButtons();
+}
+
+function clearLibrary() {
+  appState.library = defaultLibraryState();
+  saveLibrary();
+  refreshCollectionBrowsers();
+  renderAllLibraries();
+  showToast("Library cleared.");
+  updateModalButtons();
+}
+
+function openModal(item) {
+  if (!modalElements || !item) return;
+  appState.modalItemId = item.id;
+  modalElements.modalTitle.textContent = item.title;
+  modalElements.modalType.textContent = MEDIA_TYPES[item.type].label;
+  modalElements.modalMeta.textContent = `${item.creator} • ${item.year} • ${item.duration}`;
+  modalElements.modalDescription.textContent = item.summary;
+  modalElements.modalMedia.style.backgroundImage = `url('${item.image}')`;
+  modalElements.modal.setAttribute("aria-hidden", "false");
+  modalElements.modal.classList.add("open");
+  document.body.classList.add("modal-open");
+  updateModalButtons();
+}
+
+function closeModal() {
+  if (!modalElements) return;
+  modalElements.modal.setAttribute("aria-hidden", "true");
+  modalElements.modal.classList.remove("open");
+  document.body.classList.remove("modal-open");
+  appState.modalItemId = null;
+}
+
+function updateModalButtons() {
+  if (!modalElements || !appState.modalItemId) return;
+  const saved = isSaved(appState.modalItemId);
+  modalElements.modalSaveBtn.textContent = saved ? "Remove from library" : "Add to library";
+  modalElements.modalSaveBtn.classList.toggle("ghost", saved);
+  modalElements.modalSaveBtn.classList.toggle("primary", !saved);
+}
+
+function simulateDownload(item) {
+  if (!item) return;
+
+  const existing = appState.downloads.find((entry) => entry.id === item.id);
+  const timestamp = Date.now();
+
+  if (existing) {
+    existing.status = "Ready to download";
+    existing.updatedAt = timestamp;
+  } else {
+    appState.downloads.unshift({
+      id: item.id,
+      status: "Ready to download",
+      updatedAt: timestamp,
+    });
+  }
+
+  saveDownloads();
+  refreshDownloadCenters();
+  showToast(`Preparing download: ${item.title}`);
+}
+
+function createMediaCard(item) {
+  const card = document.createElement("article");
+  card.className = `media-card media-card--${item.type}`;
+  const typeInfo = MEDIA_TYPES[item.type];
+  const saved = isSaved(item.id);
+
+  card.innerHTML = `
+    <div class="media-card__visual" style="background-image: url('${item.image}')" aria-hidden="true"></div>
+    <div class="media-card__body">
+      <span class="media-card__type" style="color: ${typeInfo.accent}">${typeInfo.label}</span>
+      <h3>${item.title}</h3>
+      <p class="media-card__summary">${item.summary}</p>
+      <p class="media-card__meta">${item.creator} • ${item.year} • ${item.duration}</p>
+      <div class="media-card__tags">
+        ${item.tags.map((tag) => `<span>${tag}</span>`).join("")}
+      </div>
+      <div class="media-card__actions">
+        <button class="btn small ${saved ? "ghost" : "primary"}" data-action="toggle" data-id="${item.id}">
+          ${saved ? "In library" : "Add to library"}
+        </button>
+        <button class="btn small secondary" data-action="details" data-id="${item.id}">Details</button>
+        <button class="btn small ghost" data-action="download" data-id="${item.id}">Download</button>
+      </div>
+    </div>
+  `;
+
+  return card;
+}
+
+function createShelfItem(item) {
+  const container = document.createElement("div");
+  container.className = `shelf-item shelf-item--${item.type}`;
+  const typeInfo = MEDIA_TYPES[item.type];
+
+  if (item.type === "film" || item.type === "tv") {
+    container.innerHTML = `
+      <div class="shelf-item__visual" style="background-image: url('${item.image}')"></div>
+      <div class="shelf-item__body">
+        <h4>${item.title}</h4>
+        <p>${item.summary}</p>
+        <p class="shelf-item__meta">${item.creator} • ${item.year} • ${item.duration}</p>
+        <div class="shelf-item__actions">
+          <button class="btn small ghost" data-action="remove" data-id="${item.id}">Remove</button>
+          <button class="btn small secondary" data-action="download" data-id="${item.id}">Download</button>
+        </div>
+      </div>
+    `;
+  } else if (item.type === "music") {
+    container.innerHTML = `
+      <div class="music-thumb" style="background-image: url('${item.image}')"></div>
+      <div class="music-info">
+        <div>
+          <h4>${item.title}</h4>
+          <p>${item.creator}</p>
+        </div>
+        <span>${item.duration}</span>
+        <div class="shelf-item__actions">
+          <button class="btn small ghost" data-action="remove" data-id="${item.id}">Remove</button>
+          <button class="btn small secondary" data-action="download" data-id="${item.id}">Download</button>
+        </div>
+      </div>
+    `;
+  } else {
+    container.innerHTML = `
+      <div class="book-spine" style="background-image: url('${item.image}')"></div>
+      <div class="book-details">
+        <h4>${item.title}</h4>
+        <p>${item.creator}</p>
+        <span>${item.year} • ${item.duration}</span>
+      </div>
+      <div class="shelf-item__actions">
+        <button class="btn small ghost" data-action="remove" data-id="${item.id}">Remove</button>
+        <button class="btn small secondary" data-action="download" data-id="${item.id}">Download</button>
+      </div>
+    `;
+  }
+
+  container.dataset.id = item.id;
+  container.dataset.type = item.type;
+  container.style.setProperty("--accent", typeInfo.accent);
+  return container;
+}
+
+function createDownloadRow(item, entry) {
+  const row = document.createElement("li");
+  row.className = "download-row";
+  row.innerHTML = `
+    <div class="download-row__thumb" style="background-image: url('${item.image}')"></div>
+    <div class="download-row__body">
+      <span class="download-row__type" style="color: ${MEDIA_TYPES[item.type].accent}">${MEDIA_TYPES[item.type].label}</span>
+      <h4>${item.title}</h4>
+      <p>${item.creator} • ${item.year}</p>
+    </div>
+    <div class="download-row__meta">
+      <span class="download-row__status">${entry.status}</span>
+      <time>${new Date(entry.updatedAt).toLocaleString()}</time>
+    </div>
+    <div class="download-row__actions">
+      <button class="btn small secondary" data-action="mark-complete" data-id="${item.id}">Mark saved</button>
+      <button class="btn small ghost" data-action="remove-download" data-id="${item.id}">Remove</button>
+    </div>
+  `;
+  return row;
+}
+
+function showToast(message) {
+  if (!toastElement) return;
+  toastElement.textContent = message;
+  toastElement.classList.add("visible");
+  clearTimeout(showToast.timeoutId);
+  showToast.timeoutId = setTimeout(() => {
+    toastElement.classList.remove("visible");
+  }, 2800);
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1448 @@
+:root {
+  --bg: #0d1017;
+  --surface: #121723;
+  --surface-alt: #161d2d;
+  --surface-soft: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.08);
+  --text: #f5f7fb;
+  --text-muted: rgba(245, 247, 251, 0.72);
+  --accent: #ff8a5b;
+  --accent-alt: #6c80ff;
+  --shadow: 0 24px 48px -32px rgba(6, 12, 27, 0.5);
+  --radius-lg: 28px;
+  --radius-md: 20px;
+  --radius-sm: 12px;
+  --radius-xs: 8px;
+  --header-height: 76px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top left, rgba(255, 176, 132, 0.08), transparent 50%),
+    radial-gradient(circle at bottom right, rgba(108, 128, 255, 0.09), transparent 45%), var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+p {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: "Playfair Display", Georgia, serif;
+  font-weight: 600;
+  color: var(--text);
+  margin: 0;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  border-radius: 999px;
+  border: none;
+  padding: 0.65rem 1.4rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+  color: inherit;
+  background: rgba(255, 255, 255, 0.08);
+  backdrop-filter: blur(12px);
+}
+
+.btn:hover,
+.btn:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px -12px rgba(0, 0, 0, 0.5);
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, #ff9f6a, #ff6d87);
+  color: #0d0f14;
+}
+
+.btn.secondary {
+  background: linear-gradient(135deg, rgba(108, 128, 255, 0.2), rgba(108, 128, 255, 0.42));
+  color: var(--text);
+}
+
+.btn.ghost {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.btn.tertiary {
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--text);
+}
+
+.btn.small {
+  font-size: 0.78rem;
+  padding: 0.45rem 1rem;
+  border-radius: var(--radius-xs);
+}
+
+.btn.full {
+  width: 100%;
+}
+
+.icon-button {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+  border: none;
+  border-radius: 50%;
+  width: 38px;
+  height: 38px;
+  display: grid;
+  place-items: center;
+  font-size: 1.4rem;
+  cursor: pointer;
+}
+
+.icon-button:hover {
+  background: rgba(255, 255, 255, 0.16);
+}
+
+.app-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: var(--header-height);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 2.5rem;
+  backdrop-filter: blur(16px);
+  background: rgba(10, 13, 21, 0.68);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.brand-mark {
+  font-size: 1.5rem;
+  color: var(--accent);
+}
+
+.primary-nav {
+  display: flex;
+  gap: 1.5rem;
+  font-size: 0.95rem;
+}
+
+.primary-nav a {
+  position: relative;
+  color: var(--text-muted);
+}
+
+.primary-nav a::after {
+  content: "";
+  position: absolute;
+  inset: auto 0 -0.5rem 0;
+  height: 2px;
+  background: linear-gradient(90deg, transparent, var(--accent), transparent);
+  opacity: 0;
+  transform: scaleX(0.8);
+  transition: opacity 0.2s ease;
+}
+
+.primary-nav a:hover::after,
+.primary-nav a:focus-visible::after {
+  opacity: 1;
+}
+
+.account-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.menu-toggle {
+  display: none;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem;
+}
+
+.menu-toggle span {
+  width: 22px;
+  height: 2px;
+  background: var(--text);
+  border-radius: 999px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.menu-toggle.open span:nth-child(1) {
+  transform: translateY(6px) rotate(45deg);
+}
+
+.menu-toggle.open span:nth-child(2) {
+  opacity: 0;
+}
+
+.menu-toggle.open span:nth-child(3) {
+  transform: translateY(-6px) rotate(-45deg);
+}
+
+main {
+  padding: 0 2.5rem 6rem;
+}
+
+.hero {
+  min-height: calc(100vh - var(--header-height));
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 2.5rem;
+  align-items: center;
+  padding: 4rem 0 5rem;
+}
+
+.hero__content {
+  grid-column: span 6;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero__content h1 {
+  font-size: clamp(2.5rem, 4vw, 3.6rem);
+}
+
+.hero__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero__stats {
+  display: flex;
+  gap: 1.5rem;
+  flex-wrap: wrap;
+}
+
+.hero__stats div {
+  padding: 1rem 1.25rem;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: var(--radius-md);
+  min-width: 160px;
+}
+
+.hero__stats strong {
+  display: block;
+  font-size: 1.5rem;
+}
+
+.hero__preview {
+  grid-column: span 6;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.hero-card {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: var(--shadow);
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  opacity: 0.3;
+  background: linear-gradient(135deg, rgba(255, 176, 132, 0.25), rgba(108, 128, 255, 0.2));
+  pointer-events: none;
+}
+
+.hero-card--film {
+  border-left: 4px solid #ec6a5f;
+}
+
+.hero-card--book {
+  border-left: 4px solid #cba96e;
+}
+
+.hero-card__eyebrow {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.22em;
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.feature-strip {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 5rem;
+}
+
+.feature-strip article {
+  background: var(--surface);
+  padding: 1.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.section-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.5rem;
+  align-items: flex-end;
+  margin-bottom: 2rem;
+}
+
+.section-heading h2 {
+  font-size: clamp(2rem, 3vw, 2.8rem);
+}
+
+.section-heading input {
+  background: rgba(255, 255, 255, 0.08);
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  color: var(--text);
+  min-width: 260px;
+}
+
+.section-heading input::placeholder {
+  color: rgba(245, 247, 251, 0.45);
+}
+
+.category-tabs {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 2rem;
+}
+
+.tab-btn {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  padding: 0.55rem 1.2rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, border 0.2s ease;
+}
+
+.tab-btn.active {
+  color: var(--text);
+  border-color: rgba(255, 255, 255, 0.18);
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.explore__layout {
+  display: grid;
+  grid-template-columns: 3fr 1.15fr;
+  gap: 2.5rem;
+}
+
+.results-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.media-card {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  display: grid;
+  grid-template-rows: 200px auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.media-card__visual {
+  background-size: cover;
+  background-position: center;
+}
+
+.media-card__body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.media-card__type {
+  text-transform: uppercase;
+  font-size: 0.7rem;
+  letter-spacing: 0.3em;
+}
+
+.media-card__summary {
+  color: rgba(245, 247, 251, 0.75);
+  min-height: 72px;
+}
+
+.media-card__meta {
+  font-size: 0.85rem;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.media-card__tags {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.media-card__tags span {
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  font-size: 0.75rem;
+}
+
+.media-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: auto;
+}
+
+.media-card--book .media-card__visual {
+  filter: saturate(1.1) contrast(1.05);
+}
+
+.media-card--film .media-card__visual,
+.media-card--tv .media-card__visual {
+  filter: saturate(1.1);
+}
+
+.media-card--music .media-card__visual {
+  background-size: cover;
+  position: relative;
+}
+
+.media-card--music .media-card__visual::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(180deg, rgba(12, 16, 30, 0) 30%, rgba(12, 16, 30, 0.45));
+}
+
+.curator-spotlight {
+  background: var(--surface);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  position: sticky;
+  top: calc(var(--header-height) + 1.5rem);
+  height: fit-content;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.curator-spotlight h3 {
+  font-size: 1.25rem;
+}
+
+.library {
+  margin-top: 6rem;
+  margin-bottom: 6rem;
+}
+
+.library__notice {
+  background: var(--surface);
+  padding: 2.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  margin-bottom: 3rem;
+}
+
+.library__notice[hidden] {
+  display: none;
+}
+
+.library-shelves {
+  display: grid;
+  gap: 2rem;
+}
+
+.shelf {
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.04), rgba(255, 255, 255, 0.08));
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.shelf header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.shelf__content {
+  display: grid;
+  gap: 1rem;
+}
+
+.shelf__empty {
+  margin: 0;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.shelf-item {
+  display: grid;
+  gap: 1rem;
+  align-items: center;
+  padding: 1rem;
+  border-radius: var(--radius-sm);
+  background: rgba(0, 0, 0, 0.22);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.shelf-item__actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.shelf-item--film,
+.shelf-item--tv {
+  grid-template-columns: 180px 1fr;
+}
+
+.shelf-item__visual {
+  background-size: cover;
+  background-position: center;
+  border-radius: var(--radius-sm);
+  min-height: 120px;
+}
+
+.shelf-item__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.shelf-item__meta {
+  color: rgba(245, 247, 251, 0.6);
+  font-size: 0.85rem;
+}
+
+.shelf-item--book,
+.shelf-item--article {
+  grid-template-columns: 80px 1fr auto;
+}
+
+.book-spine {
+  background-size: cover;
+  background-position: center;
+  border-radius: var(--radius-xs);
+  min-height: 110px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.book-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.book-details span {
+  color: rgba(245, 247, 251, 0.6);
+  font-size: 0.85rem;
+}
+
+.shelf-item--music {
+  grid-template-columns: 64px 1fr;
+  align-items: center;
+}
+
+.music-thumb {
+  width: 64px;
+  height: 64px;
+  border-radius: 18px;
+  background-size: cover;
+  background-position: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.music-info {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 1rem;
+  align-items: center;
+}
+
+.music-info p {
+  margin: 0;
+}
+
+.community {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2.5rem;
+  padding: 3.5rem;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(255, 138, 91, 0.18), rgba(108, 128, 255, 0.22));
+  border: 1px solid rgba(255, 255, 255, 0.15);
+}
+
+.community__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.community__actions {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.community__stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.community__stats strong {
+  font-size: 2.25rem;
+}
+
+.site-footer {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.5rem;
+  padding: 3rem 2.5rem 4rem;
+  background: rgba(7, 9, 13, 0.9);
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.site-footer nav {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.footnote {
+  color: rgba(245, 247, 251, 0.5);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(5, 7, 13, 0.8);
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  padding: 1.5rem;
+  z-index: 200;
+}
+
+.modal.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.modal__content {
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  max-width: 900px;
+  width: min(90vw, 900px);
+  display: grid;
+  grid-template-columns: 1.3fr 1fr;
+  position: relative;
+  overflow: hidden;
+  box-shadow: 0 48px 96px -48px rgba(0, 0, 0, 0.65);
+}
+
+.modal__media {
+  background-size: cover;
+  background-position: center;
+  min-height: 320px;
+}
+
+.modal__details {
+  padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modal__type {
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.75rem;
+  color: rgba(245, 247, 251, 0.7);
+}
+
+.modal__actions {
+  display: flex;
+  gap: 0.75rem;
+  margin-top: auto;
+}
+
+.modal__close {
+  position: absolute;
+  top: 1rem;
+  right: 1rem;
+}
+
+.toast {
+  position: fixed;
+  bottom: 2rem;
+  left: 50%;
+  transform: translate(-50%, 30px);
+  background: rgba(12, 16, 28, 0.92);
+  color: var(--text);
+  padding: 0.85rem 1.4rem;
+  border-radius: 999px;
+  box-shadow: 0 18px 32px -18px rgba(0, 0, 0, 0.6);
+  opacity: 0;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 300;
+}
+
+.toast.visible {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+
+.account-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 9, 13, 0.85);
+  display: grid;
+  place-items: center;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 150;
+  padding: 1.5rem;
+}
+
+.account-panel.open {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.account-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.25rem;
+}
+
+.account-panel__lead {
+  margin-bottom: 1.5rem;
+}
+
+.account-panel__footnote {
+  margin-top: 1.5rem;
+  font-size: 0.8rem;
+  color: rgba(245, 247, 251, 0.6);
+}
+
+.account-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.account-form label {
+  font-weight: 500;
+  font-size: 0.9rem;
+}
+
+.account-form input {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  border-radius: var(--radius-xs);
+  padding: 0.65rem 0.85rem;
+  color: var(--text);
+}
+
+.account-form input:focus-visible {
+  outline: 2px solid rgba(108, 128, 255, 0.6);
+}
+
+.account-panel .account-form,
+.account-panel__lead,
+.account-panel__footnote {
+  max-width: 420px;
+}
+
+.account-panel__container {
+  background: var(--surface);
+  padding: 2.25rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+  width: min(420px, 90vw);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.empty-state {
+  background: rgba(255, 255, 255, 0.04);
+  border-radius: var(--radius-md);
+  padding: 2.5rem;
+  text-align: center;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+@media (max-width: 1080px) {
+  .hero {
+    grid-template-columns: repeat(1, 1fr);
+  }
+
+  .hero__content,
+  .hero__preview {
+    grid-column: span 12;
+  }
+
+  .hero__preview {
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  }
+
+  .explore__layout {
+    grid-template-columns: 1fr;
+  }
+
+  .curator-spotlight {
+    position: static;
+  }
+
+  .modal__content {
+    grid-template-columns: 1fr;
+  }
+
+  .modal__media {
+    min-height: 220px;
+  }
+}
+
+@media (max-width: 860px) {
+  .app-header {
+    padding: 0 1.5rem;
+  }
+
+  .primary-nav {
+    position: fixed;
+    inset: var(--header-height) 1.5rem auto;
+    display: flex;
+    flex-direction: column;
+    background: rgba(11, 14, 22, 0.96);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    gap: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    transform: translateY(-20px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .primary-nav.open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .account-actions {
+    gap: 0.5rem;
+  }
+
+  .menu-toggle {
+    display: flex;
+  }
+
+  .primary-nav a {
+    color: var(--text);
+  }
+
+  .hero {
+    padding-top: 3rem;
+  }
+
+  main {
+    padding: 0 1.5rem 5rem;
+  }
+
+  .music-info {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .library-shelves {
+    gap: 1.5rem;
+  }
+
+  .community {
+    padding: 2.5rem;
+  }
+}
+
+@media (max-width: 640px) {
+  .app-header {
+    height: auto;
+    flex-wrap: wrap;
+    gap: 1rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+  }
+
+  .account-actions {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .hero__stats {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-heading {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .section-heading input {
+    width: 100%;
+  }
+
+  .shelf-item--film,
+  .shelf-item--tv,
+  .shelf-item--book,
+  .shelf-item--article {
+    grid-template-columns: 1fr;
+  }
+
+  .shelf-item__visual,
+  .book-spine {
+    min-height: 180px;
+  }
+
+  .music-thumb {
+    width: 56px;
+    height: 56px;
+  }
+
+  .modal__content {
+    width: 100%;
+  }
+
+  .community {
+    padding: 2rem;
+  }
+
+  .site-footer {
+    grid-template-columns: 1fr;
+  }
+}
+
+.primary-nav a.active {
+  color: var(--text);
+}
+
+.primary-nav a.active::after {
+  opacity: 1;
+  transform: scaleX(1);
+}
+
+.pill {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 0.6rem 1.25rem;
+  background: rgba(12, 18, 32, 0.6);
+  color: var(--text-muted);
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.pill.active,
+.pill:hover,
+.pill:focus-visible {
+  background: rgba(255, 138, 91, 0.2);
+  color: var(--text);
+}
+
+.page-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(0, 1fr);
+  gap: 2.5rem;
+  padding: 4.5rem clamp(1.5rem, 5vw, 5rem);
+  margin: 3rem auto;
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(255, 138, 91, 0.12), rgba(108, 128, 255, 0.08));
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.page-hero__content p + .page-hero__actions {
+  margin-top: 2rem;
+}
+
+.page-hero__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.page-hero__meta {
+  background: rgba(12, 18, 32, 0.65);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  align-self: center;
+}
+
+.page-hero__meta h3 {
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.75rem;
+  margin-bottom: 1rem;
+  color: var(--text-muted);
+}
+
+.page-hero__meta ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+  color: var(--text-muted);
+}
+
+.summary-list {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: grid;
+  gap: 0.65rem;
+  color: var(--text-muted);
+}
+
+.summary-list strong {
+  display: inline-block;
+  min-width: 2.5rem;
+  font-size: 1.5rem;
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.page-hero--collections {
+  background: linear-gradient(135deg, rgba(255, 176, 132, 0.18), rgba(80, 112, 255, 0.12));
+}
+
+.page-hero--books {
+  background: linear-gradient(135deg, rgba(203, 169, 110, 0.16), rgba(255, 214, 172, 0.08));
+}
+
+.page-hero--films {
+  background: linear-gradient(135deg, rgba(236, 106, 95, 0.18), rgba(63, 84, 173, 0.12));
+}
+
+.page-hero--tv {
+  background: linear-gradient(135deg, rgba(108, 128, 255, 0.18), rgba(156, 108, 255, 0.12));
+}
+
+.page-hero--music {
+  background: linear-gradient(135deg, rgba(60, 191, 138, 0.18), rgba(253, 219, 146, 0.12));
+}
+
+.page-hero--articles {
+  background: linear-gradient(135deg, rgba(156, 108, 255, 0.18), rgba(108, 128, 255, 0.08));
+}
+
+.page-hero--library {
+  background: linear-gradient(135deg, rgba(255, 138, 91, 0.16), rgba(60, 191, 138, 0.1));
+}
+
+.page-hero--downloads {
+  background: linear-gradient(135deg, rgba(108, 128, 255, 0.18), rgba(255, 176, 132, 0.12));
+}
+
+.page-hero--community {
+  background: linear-gradient(135deg, rgba(255, 176, 132, 0.18), rgba(60, 191, 138, 0.12));
+}
+
+.page-hero--about {
+  background: linear-gradient(135deg, rgba(255, 138, 91, 0.18), rgba(156, 108, 255, 0.12));
+}
+
+.media-room {
+  margin: 4rem auto;
+  padding: 3rem clamp(1.5rem, 5vw, 4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.6);
+  box-shadow: var(--shadow);
+}
+
+.media-room .results-grid {
+  margin-top: 2rem;
+}
+
+.library-shelves--compact {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.library-shelves--compact .shelf {
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.55);
+}
+
+.collection-guides,
+.mix-board,
+.briefing-board,
+.events,
+.download-guidelines {
+  margin: 4rem auto;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+.guide-grid,
+.mix-grid,
+.briefing-grid,
+.events-grid,
+.guideline-grid,
+.festival-grid,
+.live-cards,
+.contact-card,
+.mission-grid,
+.team-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.guide-card,
+.mix-grid article,
+.briefing-grid article,
+.events-grid article,
+.guideline-grid article,
+.festival-grid article,
+.live-cards article,
+.contact-card > div,
+.mission-grid article,
+.team-grid article {
+  padding: 1.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.6);
+  box-shadow: var(--shadow);
+}
+
+.guide-card h3,
+.mix-grid h3,
+.briefing-grid h3,
+.events-grid h3,
+.guideline-grid h3,
+.festival-grid h3,
+.live-cards h3,
+.contact-card h3,
+.mission-grid h3,
+.team-grid h3 {
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.guide-panel {
+  margin: 4rem auto;
+  padding: 3rem clamp(1.5rem, 5vw, 4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: linear-gradient(135deg, rgba(203, 169, 110, 0.12), rgba(12, 18, 32, 0.7));
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.guide-panel__media {
+  min-height: 240px;
+  border-radius: var(--radius-md);
+  background: url("https://images.unsplash.com/photo-1521587760476-6c12a4b040da?auto=format&fit=crop&w=900&q=80") center / cover;
+  border: 1px solid var(--border);
+}
+
+.festival-section {
+  margin: 4rem auto;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+.live-grid,
+.mix-board,
+.briefing-board {
+  padding-bottom: 3rem;
+}
+
+.story-switcher {
+  margin: 2rem 0;
+  padding: 2.5rem;
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.6);
+}
+
+.story-switcher__tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.story-card {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+}
+
+.timeline {
+  margin: 4rem auto;
+  padding: 0 clamp(1.5rem, 5vw, 4rem);
+}
+
+.timeline__controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
+.timeline__panels {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.timeline__panels article {
+  padding: 1.75rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.6);
+}
+
+.download-dashboard,
+.download-preview {
+  margin: 4rem auto;
+  padding: 3rem clamp(1.5rem, 5vw, 4rem);
+  border-radius: var(--radius-lg);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.6);
+  box-shadow: var(--shadow);
+}
+
+.download-empty {
+  border-radius: var(--radius-md);
+  border: 1px dashed var(--border);
+  padding: 1.75rem;
+  text-align: center;
+  color: var(--text-muted);
+}
+
+.download-list {
+  list-style: none;
+  margin: 2rem 0 0;
+  padding: 0;
+  display: grid;
+  gap: 1.5rem;
+}
+
+.download-row {
+  display: grid;
+  grid-template-columns: 120px minmax(0, 2fr) minmax(0, 1fr) auto;
+  gap: 1.5rem;
+  align-items: center;
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  background: rgba(12, 18, 32, 0.65);
+}
+
+.download-row__thumb {
+  width: 120px;
+  height: 80px;
+  border-radius: var(--radius-sm);
+  background-size: cover;
+  background-position: center;
+}
+
+.download-row__type {
+  font-family: "Inter", sans-serif;
+  font-size: 0.75rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.download-row__meta {
+  display: grid;
+  gap: 0.35rem;
+  justify-items: flex-start;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.download-row__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-grid {
+  margin-top: 2rem;
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.form-grid label {
+  display: grid;
+  gap: 0.5rem;
+  font-weight: 500;
+}
+
+.form-grid label input,
+.form-grid label select,
+.form-grid label textarea {
+  background: rgba(12, 18, 32, 0.65);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 0.75rem 1rem;
+  color: var(--text);
+  font: inherit;
+}
+
+.form-grid label textarea {
+  resize: vertical;
+}
+
+.form-grid label.full {
+  grid-column: 1 / -1;
+}
+
+.form-footnote {
+  margin-top: 1rem;
+  font-size: 0.85rem;
+}
+
+.events-grid article,
+.guideline-grid article,
+.festival-grid article,
+.live-cards article {
+  min-height: 160px;
+}
+
+@media (max-width: 960px) {
+  .page-hero {
+    grid-template-columns: 1fr;
+    padding: 3rem 1.5rem;
+  }
+
+  .page-hero__meta {
+    justify-self: stretch;
+  }
+
+  .download-row {
+    grid-template-columns: 1fr;
+    text-align: left;
+  }
+
+  .download-row__actions {
+    flex-direction: row;
+  }
+}
+
+@media (max-width: 720px) {
+  .download-dashboard,
+  .download-preview,
+  .media-room,
+  .story-switcher,
+  .guide-panel {
+    padding: 2rem 1.25rem;
+  }
+}

--- a/tv.html
+++ b/tv.html
@@ -1,0 +1,194 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ZomiHub TV Studio</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Playfair+Display:wght@600&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body data-page="tv">
+    <header class="app-header" id="top">
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">✧</span>
+        <a class="brand-name" href="index.html">ZomiHub</a>
+      </div>
+      <nav class="primary-nav" aria-label="Primary navigation">
+        <a href="index.html" data-nav="home">Home</a>
+        <a href="collections.html" data-nav="collections">Collections</a>
+        <a href="books.html" data-nav="books">Books</a>
+        <a href="films.html" data-nav="films">Films</a>
+        <a href="tv.html" data-nav="tv">TV</a>
+        <a href="music.html" data-nav="music">Music</a>
+        <a href="articles.html" data-nav="articles">Articles</a>
+        <a href="library.html" data-nav="library">My Library</a>
+        <a href="downloads.html" data-nav="downloads">Downloads</a>
+        <a href="community.html" data-nav="community">Community</a>
+        <a href="about.html" data-nav="about">About</a>
+      </nav>
+      <div class="account-actions">
+        <a class="btn ghost" id="downloadCenter" href="downloads.html">Downloads</a>
+        <button class="btn primary" id="signInButton">Sign in</button>
+        <button class="menu-toggle" id="menuToggle" aria-label="Toggle navigation">
+          <span></span>
+          <span></span>
+          <span></span>
+        </button>
+      </div>
+    </header>
+
+    <aside class="account-panel" id="accountPanel" aria-hidden="true">
+      <div class="account-panel__container">
+        <div class="account-panel__header">
+          <h2>Welcome back</h2>
+          <button class="icon-button" id="closeAccountPanel" aria-label="Close account panel">×</button>
+        </div>
+        <p class="account-panel__lead">
+          Sign in to sync your ZomiHub library across the web app and mobile app.
+        </p>
+        <form class="account-form">
+          <label for="email">Email</label>
+          <input type="email" id="email" placeholder="you@example.com" required />
+          <label for="password">Password</label>
+          <input type="password" id="password" placeholder="Enter your password" required />
+          <button type="submit" class="btn primary full">Continue</button>
+          <button type="button" class="btn ghost full" id="createAccount">Create a new account</button>
+        </form>
+        <p class="account-panel__footnote">
+          By continuing you agree to our community guidelines and cultural stewardship pledge.
+        </p>
+      </div>
+    </aside>
+
+    <main>
+      <section class="page-hero page-hero--tv">
+        <div class="page-hero__content">
+          <p class="eyebrow">TV Studio</p>
+          <h1>Series and broadcasts for classrooms and families.</h1>
+          <p>
+            Watch episodic programs, interview series, and educational shows produced with Zomi presenters. Create watch lists for
+            weekly lessons or family movie nights.
+          </p>
+          <div class="page-hero__actions">
+            <a class="btn primary" href="#catalog">Browse seasons</a>
+            <a class="btn secondary" href="#live">Upcoming livestreams</a>
+          </div>
+        </div>
+        <div class="page-hero__meta">
+          <h3>Program formats</h3>
+          <ul>
+            <li>Language learning episodes with worksheets</li>
+            <li>Interview shows with downloadable transcripts</li>
+            <li>Lifestyle series featuring cuisine and crafts</li>
+          </ul>
+        </div>
+      </section>
+
+      <section
+        class="media-room"
+        id="catalog"
+        data-component="collection-browser"
+        data-default-category="tv"
+        data-categories="tv"
+      >
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">TV catalog</p>
+            <h2>Curated season guides</h2>
+          </div>
+          <div class="explore__controls">
+            <label for="tvSearch" class="sr-only">Search TV shows</label>
+            <input id="tvSearch" type="search" placeholder="Search series or host" data-role="search" />
+          </div>
+        </header>
+        <div class="category-tabs" role="tablist" aria-label="TV categories">
+          <button class="tab-btn active" role="tab" data-category="tv">TV</button>
+        </div>
+        <div class="results-grid" aria-live="polite"></div>
+      </section>
+
+      <section class="library" data-component="library-shelves">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Your watchlist</p>
+            <h2>Schedule future viewings</h2>
+          </div>
+          <button class="btn secondary" data-action="clear-library">Clear library</button>
+        </header>
+        <div class="library-shelves">
+          <section class="shelf shelf--tv" data-shelf="tv">
+            <header>
+              <h3>Saved TV series</h3>
+              <p>Track where you left off and plan the next episode.</p>
+            </header>
+            <div class="shelf__content"></div>
+          </section>
+        </div>
+      </section>
+
+      <section class="live-grid" id="live">
+        <header class="section-heading">
+          <div>
+            <p class="eyebrow">Coming soon</p>
+            <h2>Upcoming livestreams</h2>
+          </div>
+        </header>
+        <div class="live-cards">
+          <article>
+            <h3>Language Lab Live</h3>
+            <p>Interactive lesson with Nuam Bawi streaming this Saturday.</p>
+          </article>
+          <article>
+            <h3>Festival Kitchen</h3>
+            <p>Join Chef Van Lian to prepare seasonal dishes with home substitutions.</p>
+          </article>
+          <article>
+            <h3>Voices in Focus</h3>
+            <p>Live interviews with Zomi youth leaders discussing cultural stewardship.</p>
+          </article>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div>
+        <strong>ZomiHub</strong>
+        <p>Preserving Zomi culture through respectful, community-led storytelling.</p>
+      </div>
+      <nav aria-label="Footer">
+        <a href="index.html">Home</a>
+        <a href="collections.html">Collections</a>
+        <a href="library.html">My Library</a>
+        <a href="community.html">Community</a>
+        <a href="about.html">About</a>
+      </nav>
+      <p class="footnote">© 2024 ZomiHub Collective. All rights reserved.</p>
+    </footer>
+
+    <div class="modal" id="itemModal" aria-hidden="true" role="dialog" aria-modal="true" aria-labelledby="modalTitle">
+      <div class="modal__content">
+        <button class="icon-button modal__close" id="closeModal" aria-label="Close detail view">×</button>
+        <div class="modal__media"></div>
+        <div class="modal__details">
+          <p class="modal__type"></p>
+          <h3 id="modalTitle"></h3>
+          <p class="modal__meta"></p>
+          <p class="modal__description"></p>
+          <div class="modal__actions">
+            <button class="btn primary" id="modalSave">Add to library</button>
+            <button class="btn secondary" id="modalDownload">Download</button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="toast" id="toast" role="status" aria-live="polite"></div>
+
+    <script src="script.js" type="module"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated Collections, Books, Films, TV, Music, Articles, Library, Downloads, Community, and About pages that mirror media-specific apps and link together with a shared header and footer
- refactor the JavaScript into reusable collection, library, and download components that persist user selections across pages and power new timeline/story interactions
- expand the visual system with page hero layouts, grid guides, download center styling, and documented navigation updates in the README
- add a GitHub Pages deployment workflow and updated local preview instructions so the prototype can be explored live

## Testing
- not run (static site changes only)


------
https://chatgpt.com/codex/tasks/task_e_68e57a2af7a08325ad0a4540dd43d785